### PR TITLE
docs: add Python FFI example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "vita49",
     "vita49_macros",
     "cxx_demo",
+    "pyo3_demo",
     "vita49/examples/nats_control",
 ]
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,11 @@ using VITA packets. For an example of both sides of a C2 flow, see
 For an example of how to use this crate from a C++ app, see
 [`cxx_demo/README.md`](cxx_demo/README.md).
 
+## Python Interoperability
+
+For an example of how to use this crate from a Python app, see
+[`pyo3_demo/README.md`](pyo3_demo/README.md).
+
 ## Crate features
 
 By default, this crate does not enable any of its optional features, leaving

--- a/pyo3_demo/.gitignore
+++ b/pyo3_demo/.gitignore
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2026 The vita49-rs Authors
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+/target
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+.pytest_cache/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+.venv/
+env/
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+include/
+man/
+venv/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+pip-selfcheck.json
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Rope
+.ropeproject
+
+# Django stuff:
+*.log
+*.pot
+
+.DS_Store
+
+# Sphinx documentation
+docs/_build/
+
+# PyCharm
+.idea/
+
+# VSCode
+.vscode/
+
+# Pyenv
+.python-version

--- a/pyo3_demo/Cargo.toml
+++ b/pyo3_demo/Cargo.toml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 The vita49-rs Authors
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+[package]
+name = "pyo3_demo"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+name = "pyo3_demo"
+crate-type = ["cdylib"]
+
+[dependencies]
+vita49 = { version = "0.0.6", path = "../vita49" }
+pyo3 = "0.27.0"
+jiff = "0.2.18"

--- a/pyo3_demo/README.md
+++ b/pyo3_demo/README.md
@@ -1,0 +1,157 @@
+# Using the `vita49` Crate from a Python Application
+<!--
+SPDX-FileCopyrightText: 2026 The vita49-rs Authors
+
+SPDX-License-Identifier: MIT OR Apache-2.0
+-->
+
+Python has a huge ecosystem of AI/ML libraries and useful math libraries
+(e.g. numpy, pandas, etc.). It's also handy for quick CLI applications
+for hardware control. To that end, it can be useful to have Python apps
+use the `vita49` crate for the binary marshalling of VITA 49.2 packets
+while the main business logic is handled in Python.
+
+To achieve this, let's use [PyO3](https://pyo3.rs/v0.27.2/index.html)
+to handle FFI.
+
+## Defining the Foreign Function Interface (FFI)
+
+PyO3 has [excellent documentation](https://pyo3.rs/v0.27.2/getting-started.html),
+but in brief, you define an FFI layer in a Rust file with annotations
+showing how to access things from Python. For example:
+
+```rust
+#[pyclass]
+struct VrtClient {
+    dest: String,
+    socket: std::net::UdpSocket,
+    stream_id: Option<u32>,
+}
+
+#[pymethods]
+impl VrtClient {
+    #[new]
+    fn new(dest: String, stream_id: Option<u32>) -> PyResult<Self> {
+        unimplemented!()
+    }
+
+    fn send_cmd(&self, rf_ref_freq_hz: Option<f64>, bandwidth_hz: Option<f64>) -> PyResult<VrtAck> {
+        unimplemented!()
+    }
+}
+
+#[pymodule]
+mod pyo3_demo {
+    #[pymodule_export]
+    use super::VrtClient;
+}
+```
+
+Then, from the Python side, you do:
+
+```python
+import pyo3_demo
+vrt_client = pyo3_demo.VrtClient("127.0.0.1:4991", 1234)
+ack = vrt_client.send_cmd(10000, 100000000)
+```
+
+For details, see the [`src/lib.rs`](src/lib.rs) and
+[`test_send.py`](test_send.py) files.
+
+## Try it out
+
+```bash
+# Set up a new virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
+
+# Install maturin (used to generate the FFI)
+python3 -m pip install maturin
+maturin develop
+```
+
+From here, you should be able to run Python and import the demo:
+
+```python3
+import pyo3_demo
+help(pyo3_demo)
+```
+
+```
+Help on package pyo3_demo:
+
+NAME
+    pyo3_demo - A Python module implemented in Rust.
+
+PACKAGE CONTENTS
+    pyo3_demo
+
+CLASSES
+    builtins.object
+        builtins.VrtAck
+        builtins.VrtClient
+
+    class VrtAck(object)
+     |  Data descriptors defined here:
+     |
+     |  ok
+
+    class VrtClient(object)
+     |  VrtClient(dest, stream_id)
+     |
+     |  Methods defined here:
+     |
+     |  send_cmd(self, /, rf_ref_freq_hz, bandwidth_hz)
+     |
+     |  ----------------------------------------------------------------------
+     |  Static methods defined here:
+     |
+     |  __new__(*args, **kwargs)
+     |      Create and return a new object.  See help(type) for accurate signature.
+
+DATA
+    __all__ = ['VrtAck', 'VrtClient']
+```
+
+A test program ([`test_send.py`](test_send.py)) shows how to do a basic C2 flow using
+Python and the FFI.
+
+You can launch the example UDP recv application at the top-level of this repo:
+
+```bash
+cargo run --example udp_recv
+```
+
+And then in another window, launch the `test_send.py` command:
+
+```bash
+./test_send.py -d 127.0.0.1:4991 -s 1 -b 40000 -f 100000000
+```
+
+This will send a command packet to the `udp_recv` app which will
+receive it and send an ACK back to the sender.
+
+```
+Entering receive loop...
+Got command packet:
+CAM:
+  Controllee enabled: false
+  Controllee ID format: Id32bit
+  Controller enabled: false
+  Controller ID format: Id32bit
+  Partial packet impl permitted: true
+  Warnings permitted: true
+  Errors permitted: false
+  Action mode: Execute
+  NACK only: false
+  Validation: false
+  Execution: true
+  State: false
+  Warning: true
+  Error: true
+  Timing control: IgnoreTimestamp
+Message ID: 0
+Control:
+  Bandwidth: 40000 Hz
+  RF reference frequency: 100000000 Hz
+```

--- a/pyo3_demo/pyproject.toml
+++ b/pyo3_demo/pyproject.toml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 The vita49-rs Authors
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+[build-system]
+requires = ["maturin>=1.11,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "pyo3_demo"
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+]
+dynamic = ["version"]

--- a/pyo3_demo/src/lib.rs
+++ b/pyo3_demo/src/lib.rs
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 The vita49-rs Authors
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::time::Duration;
+
+use jiff::Timestamp;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use vita49::command_prelude::*;
+use vita49::prelude::*;
+
+#[pyclass]
+struct VrtClient {
+    dest: String,
+    socket: std::net::UdpSocket,
+    stream_id: Option<u32>,
+}
+
+#[pyclass]
+struct VrtAck {
+    #[pyo3(get, set)]
+    ok: bool,
+}
+
+/// Create a new VRT control packet based on input bandwidth and frequency.
+fn create_control_message(
+    stream_id: Option<u32>,
+    bandwidth_hz: Option<f64>,
+    tune_freq_hz: Option<f64>,
+) -> Vrt {
+    // Get current timestamp to fill into the VRT packet.
+    let secs_since_epoch: u32 = Timestamp::now().as_second().try_into().unwrap();
+    let psecs_since_last_epoch_second =
+        Timestamp::now().as_nanosecond() - (secs_since_epoch as f64 * 1e12) as i128;
+
+    let mut control_packet = Vrt::new_control_packet();
+    control_packet.set_stream_id(stream_id);
+    control_packet
+        .set_integer_timestamp(Some(secs_since_epoch), Tsi::Utc)
+        .unwrap();
+    control_packet
+        .set_fractional_timestamp(Some(psecs_since_last_epoch_second as u64), Tsf::RealTimePs)
+        .unwrap();
+
+    // Set up the CAM field to execute the request and request ACKs.
+    let mut cam = ControlAckMode::default();
+    cam.set_action_mode(ActionMode::Execute);
+    cam.set_warnings_permitted();
+    cam.set_warning();
+    cam.set_error();
+    cam.set_partial_packet_impl_permitted();
+    cam.set_execution();
+
+    let command = control_packet.payload_mut().command_mut().unwrap();
+    command.set_cam(cam);
+
+    // Set the data fields.
+    let control = command.payload_mut().control_mut().unwrap();
+    control.set_rf_ref_freq_hz(tune_freq_hz);
+    control.set_bandwidth_hz(bandwidth_hz);
+
+    control_packet.update_packet_size();
+    control_packet
+}
+
+#[pymethods]
+impl VrtClient {
+    #[new]
+    fn new(dest: String, stream_id: Option<u32>) -> PyResult<Self> {
+        let socket = std::net::UdpSocket::bind("0.0.0.0:0")
+            .map_err(|e| PyValueError::new_err(format!("failed to bind to UDP socket: {e}")))?;
+
+        socket.set_read_timeout(Some(Duration::from_secs(2)))?;
+        Ok(VrtClient {
+            dest,
+            socket,
+            stream_id,
+        })
+    }
+
+    fn send_cmd(&self, rf_ref_freq_hz: Option<f64>, bandwidth_hz: Option<f64>) -> PyResult<VrtAck> {
+        let command_packet = create_control_message(self.stream_id, rf_ref_freq_hz, bandwidth_hz);
+        self.socket
+            .send_to(&command_packet.to_bytes().unwrap(), &self.dest)
+            .map_err(|e| PyValueError::new_err(format!("failed to send packet: {e}")))?;
+        let mut response_buf = [0; 4096];
+        match self.socket.recv_from(&mut response_buf) {
+            Ok((bytes_read, _src)) => {
+                let ack_packet =
+                    Vrt::try_from(&response_buf[..bytes_read]).expect("failed to parse ACK");
+                let ack_command = ack_packet.payload().command().unwrap();
+                match ack_command.payload() {
+                    CommandPayload::ExecAck(_ack) => Ok(VrtAck {
+                        ok: !ack_command.cam().error(),
+                    }),
+                    _ => Err(PyValueError::new_err("invalid ack type")),
+                }
+            }
+            Err(e) => Err(PyValueError::new_err(format!("error: {e}"))),
+        }
+    }
+}
+
+/// A Python module implemented in Rust.
+#[pymodule]
+mod pyo3_demo {
+    #[pymodule_export]
+    use super::VrtAck;
+    #[pymodule_export]
+    use super::VrtClient;
+}

--- a/pyo3_demo/test_send.py
+++ b/pyo3_demo/test_send.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 The vita49-rs Authors
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+import sys
+import argparse
+import pyo3_demo
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="py-vrt-command",
+        description="Python VITA 49.2 command script",
+    )
+    parser.add_argument(
+        "-d",
+        "--destination",
+        metavar="VITA_ENDPOINT",
+        required=True,
+        help="IP address/hostname of VITA 49.2 endpoint to control",
+    )
+    parser.add_argument(
+        "-s",
+        "--stream-id",
+        metavar="STREAM_ID",
+        type=int,
+        help="VITA 49.2 stream ID",
+    )
+    parser.add_argument(
+        "-b",
+        "--bandwidth-hz",
+        metavar="BANDWIDTH_HZ",
+        type=float,
+        help="Bandwidth to set (Hz)",
+    )
+    parser.add_argument(
+        "-f",
+        "--frequency-hz",
+        metavar="FREQUENCY_HZ",
+        type=float,
+        help="Center tune frequency (Hz)",
+    )
+
+    args = parser.parse_args(sys.argv[1:])
+
+    # Create a new VRT client (implemented in Rust)
+    vrt_client = pyo3_demo.VrtClient(args.destination, args.stream_id)
+
+    if not args.bandwidth_hz and not args.frequency_hz:
+        print("error - please pass at least one of -b or -f")
+        sys.exit(1)
+
+    # Take our input parameters and send them off to the Rust impl to
+    # actually construct and send the VITA 49.2 packet and receive an
+    # ACK.
+    ack = vrt_client.send_cmd(args.bandwidth_hz, args.frequency_hz)
+
+    if ack.ok:
+        print("Got ACK back with no errors")
+    else:
+        print("Got ACK back with errors")
+
+
+if __name__ == "__main__":
+    main()

--- a/vita49/examples/nats_control/Cargo.toml
+++ b/vita49/examples/nats_control/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/controllee.rs"
 [dependencies]
 vita49 = { path = "../.." }
 clap = { version = "4.5.35", features = ["derive"] }
-async-nats = "0.39.0"
+async-nats = "0.45.0"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "sync", "time"] }
 tokio-stream = "0.1"
 bytes = "1.10.0"


### PR DESCRIPTION
Currently, we just have one example of FFI using CXX (for C++). Let's add another one for Python FFI (using PyO3).