### PR TITLE
chore: pin az to v1.2.1 to maintain MSRV

### DIFF
--- a/vita49/Cargo.toml
+++ b/vita49/Cargo.toml
@@ -33,6 +33,7 @@ fixed = "= 1.27.0"
 half = "= 2.4.1"
 proc-macro-crate = "= 3.3.0"
 indexmap = "= 2.11.4"
+az = "= 1.2.1"
 
 [features]
 default = []


### PR DESCRIPTION
The az crate moved their MSRV to 1.85[^1] which causes our MSRV to break. As we don't need any of the features in the new version of az and there are no sec issues with v1.2.1, let's just pin it.

[^1]: https://gitlab.com/tspiteri/az/-/commit/163f625a514aba2e337766e8bc39f75de526c8fb