### PR TITLE
Unpinned fixed, half, indexmap, etc.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,4 +89,13 @@ jobs:
         with:
           toolchain: 1.71.0
       - name: Run build
-        run: cargo build --all-features --package vita49
+        run: |
+          # To build with an older Rust toolchain, we have to
+          # specify some compatible crate versions.
+          cargo generate-lockfile
+          cargo update -p fixed --precise 1.27.0
+          cargo update -p half --precise 2.4.1
+          cargo update -p proc-macro-crate --precise 3.3.0
+          cargo update -p indexmap --precise 2.11.4
+          cargo update -p az --precise 1.2.1
+          cargo build --all-features --package vita49

--- a/README.md
+++ b/README.md
@@ -386,6 +386,11 @@ updates of this crate. For example, if `vita49` `1.2.0` requires Rust `1.60.0`,
 versions `1.2.X` of `vita49` will also require Rust `1.6.0` or newer. However,
 `vita49` version `1.3.0` may require a newer minimum version of Rust.
 
+If you're using an old version of Rust, you may need to pin dependencies in your
+`Cargo.lock` file to download compatible versions. See our MSRV check in
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml) for the commands needed
+to make that build work.
+
 ## Crate Versioning
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/vita49/Cargo.toml
+++ b/vita49/Cargo.toml
@@ -28,12 +28,11 @@ env_logger = "0.11.6"
 log = "0.4.22"
 serde = { version = "1.0.218", optional = true, features = ["derive"] }
 thiserror = "2.0.11"
-# Locked versions to keep lower MSRV
-fixed = "= 1.27.0"
-half = "= 2.4.1"
-proc-macro-crate = "= 3.3.0"
-indexmap = "= 2.11.4"
-az = "= 1.2.1"
+fixed = "1.27"
+half = "2.4"
+proc-macro-crate = "3.3"
+indexmap = "2.11"
+az = "1.2"
 
 [features]
 default = []


### PR DESCRIPTION
Unpins dependencies and relies on cargo resolver 3 to handle MSRV requirements.

Note: I did *not* test this with an older version of Rust. Offering this PR as a convenience. I'm depending on a fork for now.

Closes #23