### PR TITLE
feat: make SampleFrameIndicator public

### DIFF
--- a/vita49/src/lib.rs
+++ b/vita49/src/lib.rs
@@ -67,7 +67,7 @@ pub use crate::query_ack::QueryAck;
 pub use crate::signal_data::SignalData;
 pub use crate::spectrum::*;
 pub use crate::threshold::Threshold;
-pub use crate::trailer::Trailer;
+pub use crate::trailer::{SampleFrameIndicator, Trailer};
 pub use crate::vrt::Vrt;
 
 /// Standard imports for the most commonly used structures and

--- a/vita49/src/trailer.rs
+++ b/vita49/src/trailer.rs
@@ -13,12 +13,17 @@ use deku::prelude::*;
 #[deku(id_type = "u8", endian = "endian", ctx = "endian: deku::ctx::Endian")]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SampleFrameIndicator {
+    /// Sample Frames are not applicable to data packets, or the entire Sample
+    /// Frame is contained in a single data packet
     #[deku(id = 0x0)]
     NotApplicable,
+    /// First data packet of current Sample Frame
     #[deku(id = 0x1)]
     FirstDataPacket,
+    /// Middle packet or packets of Sample Frame, i.e. "continuation" indicator
     #[deku(id = 0x2)]
     MiddleDataPacket,
+    /// Final data packet of current Sample Frame
     #[deku(id = 0x3)]
     FinalDataPacket,
 }


### PR DESCRIPTION
This pull request introduces improvements to the handling and documentation of sample frame indicators in the `vita49` crate. 

* The `SampleFrameIndicator` enum is now publicly re-exported from the crate root (`vita49/src/lib.rs`), making it publicly accessible.
* Added descriptive comments to each variant of the `SampleFrameIndicator` enum in `vita49/src/trailer.rs`, clarifying the meaning and intended use of each variant.


Closes #26