### PR TITLE
feat: FormattedGps construction API + fix Gain stage-1 sign-extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public construction API for `FormattedGps` (`Default` plus getters/setters for the
   Manufacturer OUI, TSI/TSF, position-fix timestamps, and radix-encoded geolocation values)
 
+### Fixed
+- `Gain::new` and `set_stage_1_gain_db` sign-extended a negative stage-1 gain over the
+  stage-2 half-word
+
 ## [1.1.0] - 2026-05-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Public construction API for `FormattedGps` (`Default` plus getters/setters for the
+  Manufacturer OUI, TSI/TSF, position-fix timestamps, and radix-encoded geolocation values)
+
 ## [1.1.0] - 2026-05-12
 
 ### Added

--- a/vita49/src/formatted_gps.rs
+++ b/vita49/src/formatted_gps.rs
@@ -6,12 +6,61 @@ Data structures and methods related to the formatted GPS format
 (ANSI/VITA-49.2-2017 section 9.4.5).
 */
 
+use crate::packet_header::{Tsf, Tsi};
 use deku::prelude::*;
+use fixed::types::extra::{U16, U22, U5};
+use fixed::FixedI32;
+
+/// Sentinel for an unknown angle/distance sub-field (Rule 9.4.5-18).
+const UNKNOWN: i32 = 0x7FFF_FFFF;
+/// Sentinel for an unused Timestamp-of-Position-Fix word (Rule 9.4.5-6).
+const TS_UNUSED: u32 = 0xFFFF_FFFF;
+/// Manufacturer OUI value meaning "unknown" (Permission 9.4.5-2).
+const OUI_UNKNOWN: u32 = 0x00FF_FFFF;
+
+/// Generate a paired getter/setter for a radix-encoded `i32` sub-field. `None` maps to/from
+/// the [`UNKNOWN`] sentinel; otherwise the value is a two's-complement fixed-point with the
+/// binary point right of bit `Frac`.
+macro_rules! radix_field {
+    ($get:ident, $set:ident, $field:ident, $frac:ty, $unit:literal) => {
+        #[doc = concat!("Get the ", $unit, " (`None` when unknown).")]
+        pub fn $get(&self) -> Option<f64> {
+            (self.$field != UNKNOWN).then(|| FixedI32::<$frac>::from_bits(self.$field).to_num())
+        }
+        #[doc = concat!("Set the ", $unit, " (`None` sets the unknown sentinel).")]
+        #[doc = ""]
+        #[doc = "# Panics"]
+        #[doc = ""]
+        #[doc = "Panics if the value is outside the field's representable range."]
+        pub fn $set(&mut self, v: Option<f64>) {
+            self.$field = match v {
+                Some(x) => FixedI32::<$frac>::from_num(x).to_bits(),
+                None => UNKNOWN,
+            };
+        }
+    };
+}
 
 /// Base formatted GPS data structure.
-#[derive(
-    Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, DekuRead, DekuWrite,
-)]
+///
+/// # Example
+///
+/// ```
+/// use vita49::FormattedGps;
+/// use vita49::prelude::Tsi;
+///
+/// // A default value starts with every field "unknown"; fill in what's known.
+/// let mut gps = FormattedGps::default();
+/// gps.set_manufacturer_oui(0x0A_1B2C);
+/// gps.set_tsi(Tsi::Gps);
+/// gps.set_latitude_deg(Some(-31.953_512));
+/// gps.set_longitude_deg(Some(115.857_048));
+///
+/// assert_eq!(gps.tsi(), Tsi::Gps);
+/// assert!(gps.latitude_deg().is_some());
+/// assert_eq!(gps.altitude_m(), None); // never set, so still unknown
+/// ```
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, DekuRead, DekuWrite)]
 #[deku(endian = "endian", ctx = "endian: deku::ctx::Endian")]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FormattedGps {
@@ -28,9 +77,200 @@ pub struct FormattedGps {
     magnetic_variation: i32,
 }
 
+impl Default for FormattedGps {
+    /// A field with every value unknown: OUI = `FF-FF-FF`, TSI/TSF = Null, the position-fix
+    /// timestamp unused, and every geolocation sub-field the unknown sentinel. Fill in what's
+    /// known with the setters — a partial fix stays valid.
+    fn default() -> Self {
+        Self {
+            w1: OUI_UNKNOWN, // TSI = TSF = Null (0), OUI = unknown
+            ts1: TS_UNUSED,
+            ts2: TS_UNUSED,
+            ts3: TS_UNUSED,
+            latitude: UNKNOWN,
+            longitude: UNKNOWN,
+            altitude: UNKNOWN,
+            speed_over_ground: UNKNOWN,
+            heading_angle: UNKNOWN,
+            track_angle: UNKNOWN,
+            magnetic_variation: UNKNOWN,
+        }
+    }
+}
+
 impl FormattedGps {
     /// Gets the size of the formatted GPS structure in 32-bit words.
     pub fn size_words(&self) -> u16 {
         (std::mem::size_of_val(self) / std::mem::size_of::<u32>()) as u16
+    }
+
+    /// The GPS/INS Manufacturer OUI (Rule 9.4.5-2); `FF-FF-FF` when unknown (Perm 9.4.5-2).
+    pub fn manufacturer_oui(&self) -> u32 {
+        self.w1 & 0x00FF_FFFF
+    }
+    /// Set the GPS/INS Manufacturer OUI (low 24 bits used).
+    pub fn set_manufacturer_oui(&mut self, oui: u32) {
+        self.w1 = (self.w1 & 0xFF00_0000) | (oui & 0x00FF_FFFF);
+    }
+
+    /// The integer-seconds Timestamp-of-Position-Fix type (Rule 9.4.5-3, Table 9.4.5-1).
+    pub fn tsi(&self) -> Tsi {
+        // The 2-bit field spans all four Tsi variants, so the conversion is infallible.
+        (((self.w1 >> 26) & 0b11) as u8).try_into().unwrap()
+    }
+    /// Set the integer-seconds Timestamp-of-Position-Fix type.
+    pub fn set_tsi(&mut self, tsi: Tsi) {
+        self.w1 = (self.w1 & !(0b11 << 26)) | ((tsi as u32 & 0b11) << 26);
+    }
+
+    /// The fractional-seconds Timestamp-of-Position-Fix type (Rule 9.4.5-4, Table 9.4.5-2).
+    pub fn tsf(&self) -> Tsf {
+        // The 2-bit field spans all four Tsf variants, so the conversion is infallible.
+        (((self.w1 >> 24) & 0b11) as u8).try_into().unwrap()
+    }
+    /// Set the fractional-seconds Timestamp-of-Position-Fix type.
+    pub fn set_tsf(&mut self, tsf: Tsf) {
+        self.w1 = (self.w1 & !(0b11 << 24)) | ((tsf as u32 & 0b11) << 24);
+    }
+
+    /// The integer-second Timestamp of the position fix (meaningful when [`tsi`](Self::tsi)
+    /// is non-Null).
+    pub fn integer_timestamp(&self) -> u32 {
+        self.ts1
+    }
+    /// Set the integer-second Timestamp of the position fix.
+    pub fn set_integer_timestamp(&mut self, seconds: u32) {
+        self.ts1 = seconds;
+    }
+
+    /// The 64-bit fractional-second Timestamp of the position fix.
+    pub fn fractional_timestamp(&self) -> u64 {
+        (u64::from(self.ts2) << 32) | u64::from(self.ts3)
+    }
+    /// Set the 64-bit fractional-second Timestamp of the position fix.
+    pub fn set_fractional_timestamp(&mut self, frac: u64) {
+        self.ts2 = (frac >> 32) as u32;
+        self.ts3 = frac as u32;
+    }
+
+    // Geolocation Angle Format = 32-bit two's-complement, radix point right of bit 22
+    // (Def 9.4.5-1); altitude radix 5 (Rule 9.4.5-10); speed radix 16 (Rule 9.4.5-11).
+    radix_field!(
+        latitude_deg,
+        set_latitude_deg,
+        latitude,
+        U22,
+        "latitude in degrees"
+    );
+    radix_field!(
+        longitude_deg,
+        set_longitude_deg,
+        longitude,
+        U22,
+        "longitude in degrees"
+    );
+    radix_field!(
+        altitude_m,
+        set_altitude_m,
+        altitude,
+        U5,
+        "altitude in meters"
+    );
+    radix_field!(
+        speed_over_ground_mps,
+        set_speed_over_ground_mps,
+        speed_over_ground,
+        U16,
+        "speed over ground in meters/second"
+    );
+    radix_field!(
+        heading_angle_deg,
+        set_heading_angle_deg,
+        heading_angle,
+        U22,
+        "heading angle in degrees"
+    );
+    radix_field!(
+        track_angle_deg,
+        set_track_angle_deg,
+        track_angle,
+        U22,
+        "track angle in degrees"
+    );
+    radix_field!(
+        magnetic_variation_deg,
+        set_magnetic_variation_deg,
+        magnetic_variation,
+        U22,
+        "magnetic variation in degrees"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_all_unknown() {
+        let g = FormattedGps::default();
+        assert_eq!(g.manufacturer_oui(), OUI_UNKNOWN);
+        assert_eq!(g.tsi(), Tsi::Null);
+        assert_eq!(g.tsf(), Tsf::Null);
+        assert_eq!(g.integer_timestamp(), TS_UNUSED);
+        for v in [
+            g.latitude_deg(),
+            g.longitude_deg(),
+            g.altitude_m(),
+            g.speed_over_ground_mps(),
+            g.heading_angle_deg(),
+            g.track_angle_deg(),
+            g.magnetic_variation_deg(),
+        ] {
+            assert_eq!(v, None);
+        }
+    }
+
+    #[test]
+    fn header_and_position_round_trip() {
+        let mut g = FormattedGps::default();
+        g.set_manufacturer_oui(0x0A_1B2C);
+        g.set_tsi(Tsi::Other);
+        g.set_tsf(Tsf::SampleCount);
+        g.set_integer_timestamp(1_700_000_000);
+        g.set_fractional_timestamp(0x1122_3344_5566_7788);
+        g.set_latitude_deg(Some(-31.953_512));
+        g.set_longitude_deg(Some(115.857_048));
+        g.set_altitude_m(Some(21.0));
+        g.set_speed_over_ground_mps(Some(3.5));
+
+        assert_eq!(g.manufacturer_oui(), 0x0A_1B2C);
+        assert_eq!(g.tsi(), Tsi::Other);
+        assert_eq!(g.tsf(), Tsf::SampleCount);
+        assert_eq!(g.integer_timestamp(), 1_700_000_000);
+        assert_eq!(g.fractional_timestamp(), 0x1122_3344_5566_7788);
+        // radix-22 angle resolution ≈ 2.4e-7°, radix-5 alt ≈ 0.03 m, radix-16 speed ≈ 1.5e-5
+        assert!((g.latitude_deg().unwrap() - -31.953_512).abs() < 1e-6);
+        assert!((g.longitude_deg().unwrap() - 115.857_048).abs() < 1e-6);
+        assert!((g.altitude_m().unwrap() - 21.0).abs() < 0.05);
+        assert!((g.speed_over_ground_mps().unwrap() - 3.5).abs() < 1e-3);
+        // untouched fields still unknown
+        assert_eq!(g.heading_angle_deg(), None);
+        assert_eq!(g.track_angle_deg(), None);
+    }
+
+    #[test]
+    fn wide_but_in_range_round_trips() {
+        let mut g = FormattedGps::default();
+        // 300° is out of navigational range but within the ±512° Geolocation Angle Format.
+        g.set_latitude_deg(Some(300.0));
+        assert!((g.latitude_deg().unwrap() - 300.0).abs() < 1e-4);
+    }
+
+    #[test]
+    #[should_panic(expected = "overflow")]
+    fn out_of_range_panics() {
+        // Past the field's representable range the caller is responsible for the value —
+        // `set_*` panics rather than silently clamping.
+        FormattedGps::default().set_altitude_m(Some(1.0e12));
     }
 }

--- a/vita49/src/gain.rs
+++ b/vita49/src/gain.rs
@@ -29,8 +29,10 @@ pub struct Gain(i32);
 impl Gain {
     /// Create a new `Gain` object given stage 1 and 2 gain in dB.
     pub fn new(stage_1_gain_db: f32, stage_2_gain_db: f32) -> Gain {
-        let s1 = FixedI16::<U7>::from_num(stage_1_gain_db).to_bits() as i32;
-        let s2 = FixedI16::<U7>::from_num(stage_2_gain_db).to_bits() as i32;
+        // Go through `u16` so a negative stage 1 gain doesn't sign-extend
+        // into (and clobber) the stage 2 half-word.
+        let s1 = FixedI16::<U7>::from_num(stage_1_gain_db).to_bits() as u16 as i32;
+        let s2 = FixedI16::<U7>::from_num(stage_2_gain_db).to_bits() as u16 as i32;
         Gain((s2 << 16) | s1)
     }
 
@@ -47,7 +49,9 @@ impl Gain {
 
     /// Sets stage 1 gain (dB)
     pub fn set_stage_1_gain_db(&mut self, stage_1_gain_db: f32) {
-        let s1 = FixedI16::<U7>::from_num(stage_1_gain_db).to_bits() as i32;
+        // Go through `u16` so a negative stage 1 gain doesn't sign-extend
+        // into (and clobber) the stage 2 half-word.
+        let s1 = FixedI16::<U7>::from_num(stage_1_gain_db).to_bits() as u16 as i32;
         self.0 = (self.0 & (0xFFFF_0000u32 as i32)) | s1
     }
 
@@ -59,7 +63,7 @@ impl Gain {
 
     /// Sets stage 2 gain (dB)
     pub fn set_stage_2_gain_db(&mut self, stage_2_gain_db: f32) {
-        let s2 = FixedI16::<U7>::from_num(stage_2_gain_db).to_bits() as i32;
+        let s2 = FixedI16::<U7>::from_num(stage_2_gain_db).to_bits() as u16 as i32;
         self.0 = (self.0 & 0x0000_FFFF) | (s2 << 16)
     }
 }
@@ -116,5 +120,35 @@ mod tests {
             s2,
             max_relative = 0.1
         );
+    }
+
+    #[test]
+    fn negative_gain_round_trip() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        // (stage 1, stage 2) combinations covering every sign mix. A negative
+        // stage 1 gain must not sign-extend into the stage 2 half-word.
+        let cases: [(f32, f32); 5] = [
+            (-48.2, 12.5),
+            (-48.2, 0.0),
+            (12.5, -48.2),
+            (-48.2, -1.5),
+            (-0.5, -0.25),
+        ];
+        for (s1, s2) in cases {
+            let g = Gain::new(s1, s2);
+            assert_relative_eq!(g.stage_1_gain_db(), s1, max_relative = 0.01);
+            assert_relative_eq!(g.stage_2_gain_db(), s2, max_relative = 0.01);
+        }
+    }
+
+    #[test]
+    fn negative_stage_1_setter_preserves_stage_2() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        // Set stage 2 first, then a negative stage 1: stage 2 must survive.
+        let mut g = Gain::new(0.0, 0.0);
+        g.set_stage_2_gain_db(12.5);
+        g.set_stage_1_gain_db(-48.2);
+        assert_relative_eq!(g.stage_1_gain_db(), -48.2, max_relative = 0.01);
+        assert_relative_eq!(g.stage_2_gain_db(), 12.5, max_relative = 0.01);
     }
 }


### PR DESCRIPTION
Two independent changes.

## `feat(formatted_gps)`: public construction API

`FormattedGps` could be parsed but not built — every field was private with no setters. This adds a construction API:

- `FormattedGps::default()` starts from the spec-defined "unknown" state (all fields at their VITA 49.2 unknown sentinels).
- Header accessors: `manufacturer_oui`/`set_manufacturer_oui`, `tsi`/`set_tsi`, `tsf`/`set_tsf`, and the integer/fractional position-fix timestamps.
- Radix-encoded geolocation values, with units in the method names to match the crate's convention: `latitude_deg`, `longitude_deg`, `altitude_m`, `speed_over_ground_mps`, `heading_angle_deg`, `track_angle_deg`, `magnetic_variation_deg` — angle radix 22 (Def 9.4.5-1), altitude radix 5 (Rule 9.4.5-10), speed radix 16 (Rule 9.4.5-11).
- Getters return `Option`, mapping the unknown sentinel to `None`; setters accept `Option` so a field can be returned to unknown. Out-of-range values are the caller's responsibility (`from_num`, not silent clamping).

Includes round-trip unit tests and a doc example.

## `fix(gain)`: stage-1 sign-extension clobbered stage 2

`Gain::new` packed `(s2 << 16) | s1` with `s1` sign-extended from `i16` to `i32`, so any negative stage-1 gain (e.g. `-48.2` dB) ORed `0xFFFF` over the stage-2 half-word. `set_stage_1_gain_db` had the same sign-extension and overwrote stage 2 outright — the existing test only passed because it happened to set stage 2 last.

Fixed by routing the stage words through `u16` before widening. Added round-trip tests for every sign combination (including `-48.2` dB) and a setter-ordering test proving a previously-set stage 2 survives a negative stage-1 set.
