### PR TITLE
feat: GpsAscii + ContextAssociationLists construction APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public construction API for `GpsAscii` (`Default` plus getters/setters for the
   Manufacturer OUI and the ASCII sentence payload — `set_sentences` validates ASCII and
   `sentences` returns a `Result`, per Rule 9.4.7-4)
+- Public construction API for `ContextAssociationLists` (`Default` plus getters/setters for
+  the Source, System, Vector-Component, and Asynchronous-Channel lists — and the
+  Asynchronous-Channel Tag list — keeping each list-size subfield in sync per §9.13.2)
 
 ### Fixed
 - `Gain::new` and `set_stage_1_gain_db` sign-extended a negative stage-1 gain over the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public construction API for `EcefEphemeris` (`Default` plus getters/setters for the
   Manufacturer OUI, TSI/TSF, position-fix timestamps, and the radix-encoded ECEF position,
   attitude, and velocity)
+- Public construction API for `GpsAscii` (`Default` plus getters/setters for the
+  Manufacturer OUI and the ASCII sentence payload — `set_sentences` validates ASCII and
+  `sentences` returns a `Result`, per Rule 9.4.7-4)
 
 ### Fixed
 - `Gain::new` and `set_stage_1_gain_db` sign-extended a negative stage-1 gain over the

--- a/vita49/src/context_association_lists.rs
+++ b/vita49/src/context_association_lists.rs
@@ -9,21 +9,43 @@ Data structures and methods related to context association lists
 use deku::prelude::*;
 
 /// Base context association lists structure.
+///
+/// The Context Association Lists Section (§9.13.2) associates other packet streams with the
+/// described signal by carrying their Stream IDs in up to four lists — Source, System,
+/// Vector-Component, and Asynchronous-Channel — plus an optional Asynchronous-Channel Tag
+/// list. The first two 32-bit words carry the list sizes (Figure 9.13.2-1); the lists follow.
+///
+/// The setters keep each list's `Vec` and its size bitfield in sync while preserving the
+/// other lists' sizes, so the structure always serializes to a well-formed section.
+///
+/// # Example
+///
+/// ```
+/// use vita49::ContextAssociationLists;
+///
+/// // Associate two source streams and one system stream with the described signal.
+/// let mut cal = ContextAssociationLists::default();
+/// cal.set_source_list(&[0x0000_0001, 0x0000_0002]);
+/// cal.set_system_list(&[0x0000_0010]);
+///
+/// assert_eq!(cal.source_list(), &[0x0000_0001, 0x0000_0002]);
+/// assert_eq!(cal.system_list(), &[0x0000_0010]);
+/// ```
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, DekuRead, DekuWrite)]
 #[deku(endian = "endian", ctx = "endian: deku::ctx::Endian")]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ContextAssociationLists {
     w1: u32,
     w2: u32,
-    #[deku(count = "((w1 >> 16) & 0x3FF)")]
+    #[deku(count = "((w1 >> 16) & 0x1FF)")]
     source_list: Vec<u32>,
-    #[deku(count = "(w1 & 0x3FF)")]
+    #[deku(count = "(w1 & 0x1FF)")]
     system_list: Vec<u32>,
     #[deku(count = "(w2 >> 16)")]
     vector_component_list: Vec<u32>,
-    #[deku(count = "(w2 & 0x1FF)")]
+    #[deku(count = "(w2 & 0x7FFF)")]
     async_channel_list: Vec<u32>,
-    #[deku(cond = "(w2 & (1 << 15) > 1)", count = "(w2 & 0x1FF)")]
+    #[deku(cond = "(w2 & (1 << 15)) != 0", count = "(w2 & 0x7FFF)")]
     async_channel_tag_list: Vec<u32>,
 }
 
@@ -38,5 +60,252 @@ impl ContextAssociationLists {
         ret += self.async_channel_list.len();
         ret += self.async_channel_tag_list.len();
         ret as u16
+    }
+
+    /// The Source Context Association List — Stream IDs of the input data / upstream
+    /// processes (§9.13.2.1).
+    pub fn source_list(&self) -> &[u32] {
+        &self.source_list
+    }
+
+    /// Set the Source Context Association List, updating the Source List Size (word 1 bits
+    /// 24:16) and preserving the System List Size.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ids.len() > 511`; Rule 9.13.2-2 caps the Source List Size at 511.
+    pub fn set_source_list(&mut self, ids: &[u32]) {
+        assert!(
+            ids.len() <= 511,
+            "source list size must be 0..=511 (Rule 9.13.2-2)"
+        );
+        self.w1 = (self.w1 & !(0x1FF << 16)) | ((ids.len() as u32) << 16);
+        self.source_list = ids.to_vec();
+    }
+
+    /// The System Context Association List — Stream IDs of associated system streams
+    /// (§9.13.2.2).
+    pub fn system_list(&self) -> &[u32] {
+        &self.system_list
+    }
+
+    /// Set the System Context Association List, updating the System List Size (word 1 bits
+    /// 8:0) and preserving the Source List Size.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ids.len() > 511`; Rule 9.13.2-3 caps the System List Size at 511.
+    pub fn set_system_list(&mut self, ids: &[u32]) {
+        assert!(
+            ids.len() <= 511,
+            "system list size must be 0..=511 (Rule 9.13.2-3)"
+        );
+        self.w1 = (self.w1 & !0x1FF) | (ids.len() as u32);
+        self.system_list = ids.to_vec();
+    }
+
+    /// The Vector-Component Context Association List — Stream IDs of associated
+    /// vector-component streams (§9.13.2.3).
+    pub fn vector_component_list(&self) -> &[u32] {
+        &self.vector_component_list
+    }
+
+    /// Set the Vector-Component Context Association List, updating the Vector-Component List
+    /// Size (word 2 bits 31:16) and preserving the Asynchronous-Channel fields.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ids.len() > 65_535`; Rule 9.13.2-4 caps the Vector-Component List Size at
+    /// 65,535.
+    pub fn set_vector_component_list(&mut self, ids: &[u32]) {
+        assert!(
+            ids.len() <= 65_535,
+            "vector-component list size must be 0..=65535 (Rule 9.13.2-4)"
+        );
+        self.w2 = (self.w2 & 0x0000_FFFF) | ((ids.len() as u32) << 16);
+        self.vector_component_list = ids.to_vec();
+    }
+
+    /// The Asynchronous-Channel Context Association List — Stream IDs of associated
+    /// asynchronous channels (§9.13.2.4).
+    pub fn async_channel_list(&self) -> &[u32] {
+        &self.async_channel_list
+    }
+
+    /// Set the Asynchronous-Channel Context Association List, updating the
+    /// Asynchronous-Channel List Size (word 2 bits 14:0) and preserving the Vector-Component
+    /// List Size and the "A" bit.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ids.len() > 32_767`; Rule 9.13.2-5 caps the Asynchronous-Channel List Size
+    /// at 32,767 (a 15-bit field, just below the "A" bit at bit 15).
+    pub fn set_async_channel_list(&mut self, ids: &[u32]) {
+        assert!(
+            ids.len() <= 32_767,
+            "async-channel list size must be 0..=32767 (Rule 9.13.2-5)"
+        );
+        self.w2 = (self.w2 & !0x7FFF) | (ids.len() as u32);
+        self.async_channel_list = ids.to_vec();
+    }
+
+    /// The Asynchronous-Channel Tag List — present only when the "A" bit is set (§9.13.2.4);
+    /// empty otherwise.
+    pub fn async_channel_tag_list(&self) -> &[u32] {
+        &self.async_channel_tag_list
+    }
+
+    /// Set the Asynchronous-Channel Tag List and the "A" (tag-list-present) bit (word 2 bit
+    /// 15).
+    ///
+    /// Passing a non-empty slice sets the "A" bit; passing an empty slice clears it and drops
+    /// the tag list. Per Rule 9.13.2-6, when present the tag list must be the same length as
+    /// the Asynchronous-Channel List, so set that list first.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ids` is non-empty and its length differs from the current
+    /// Asynchronous-Channel List length.
+    pub fn set_async_channel_tag_list(&mut self, ids: &[u32]) {
+        if ids.is_empty() {
+            self.w2 &= !(1 << 15);
+            self.async_channel_tag_list.clear();
+        } else {
+            assert!(
+                ids.len() == self.async_channel_list.len(),
+                "tag list length must equal the async-channel list length (Rule 9.13.2-6)"
+            );
+            self.w2 |= 1 << 15;
+            self.async_channel_tag_list = ids.to_vec();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use deku::ctx::Endian;
+    use deku::reader::Reader;
+    use deku::writer::Writer;
+    use std::io::Cursor;
+
+    /// Serialize big-endian, matching the VITA-49 wire convention (`Vrt` is `endian = "big"`).
+    fn to_be_bytes(c: &ContextAssociationLists) -> Vec<u8> {
+        let mut out = Vec::new();
+        {
+            let mut writer = Writer::new(Cursor::new(&mut out));
+            c.to_writer(&mut writer, Endian::Big).unwrap();
+            writer.finalize().unwrap();
+        }
+        out
+    }
+
+    /// Parse back the big-endian wire bytes.
+    fn from_be_bytes(bytes: &[u8]) -> ContextAssociationLists {
+        let mut cursor = Cursor::new(bytes);
+        let mut reader = Reader::new(&mut cursor);
+        ContextAssociationLists::from_reader_with_ctx(&mut reader, Endian::Big).unwrap()
+    }
+
+    #[test]
+    fn default_is_empty() {
+        let c = ContextAssociationLists::default();
+        assert!(c.source_list().is_empty());
+        assert!(c.system_list().is_empty());
+        assert!(c.vector_component_list().is_empty());
+        assert!(c.async_channel_list().is_empty());
+        assert!(c.async_channel_tag_list().is_empty());
+        assert_eq!(c.size_words(), 2);
+    }
+
+    #[test]
+    fn source_and_system_lists_round_trip() {
+        let mut c = ContextAssociationLists::default();
+        c.set_source_list(&[0x0000_0001, 0x0000_0002]);
+        c.set_system_list(&[0x0000_0010]);
+
+        // 2 header words + 2 source + 1 system.
+        assert_eq!(c.size_words(), 5);
+
+        let bytes = to_be_bytes(&c);
+        // Word 1 = Source Size (bits 25:16) | System Size (bits 9:0) = (2 << 16) | 1.
+        assert_eq!(&bytes[0..4], &0x0002_0001u32.to_be_bytes());
+        // Word 2 has no sizes set yet.
+        assert_eq!(&bytes[4..8], &0u32.to_be_bytes());
+
+        let parsed = from_be_bytes(&bytes);
+        assert_eq!(parsed, c);
+        assert_eq!(parsed.source_list(), &[0x0000_0001, 0x0000_0002]);
+        assert_eq!(parsed.system_list(), &[0x0000_0010]);
+    }
+
+    #[test]
+    fn vector_and_async_lists_round_trip() {
+        let mut c = ContextAssociationLists::default();
+        c.set_vector_component_list(&[0xAAAA_0001, 0xAAAA_0002, 0xAAAA_0003]);
+        c.set_async_channel_list(&[0xBBBB_0001, 0xBBBB_0002]);
+        // Tag list present: same length as the async-channel list (Rule 9.13.2-6).
+        c.set_async_channel_tag_list(&[0xCCCC_0001, 0xCCCC_0002]);
+
+        // 2 header + 3 vector + 2 async + 2 tag.
+        assert_eq!(c.size_words(), 9);
+
+        let bytes = to_be_bytes(&c);
+        // Word 2 = Vector Size (bits 31:16) | A bit (15) | Async Size (bits 14:0).
+        let expected_w2 = (3u32 << 16) | (1 << 15) | 2;
+        assert_eq!(&bytes[4..8], &expected_w2.to_be_bytes());
+
+        let parsed = from_be_bytes(&bytes);
+        assert_eq!(parsed, c);
+        assert_eq!(
+            parsed.vector_component_list(),
+            &[0xAAAA_0001, 0xAAAA_0002, 0xAAAA_0003]
+        );
+        assert_eq!(parsed.async_channel_list(), &[0xBBBB_0001, 0xBBBB_0002]);
+        assert_eq!(parsed.async_channel_tag_list(), &[0xCCCC_0001, 0xCCCC_0002]);
+    }
+
+    #[test]
+    fn clearing_tag_list_clears_the_a_bit() {
+        let mut c = ContextAssociationLists::default();
+        c.set_async_channel_list(&[0xBBBB_0001]);
+        c.set_async_channel_tag_list(&[0xCCCC_0001]);
+        assert_eq!(c.async_channel_tag_list(), &[0xCCCC_0001]);
+
+        c.set_async_channel_tag_list(&[]);
+        assert!(c.async_channel_tag_list().is_empty());
+
+        // "A" bit cleared, so the parsed value omits the tag list.
+        let parsed = from_be_bytes(&to_be_bytes(&c));
+        assert_eq!(parsed, c);
+        assert!(parsed.async_channel_tag_list().is_empty());
+        assert_eq!(parsed.async_channel_list(), &[0xBBBB_0001]);
+    }
+
+    #[test]
+    #[should_panic(expected = "source list size must be 0..=511")]
+    fn source_list_over_cap_panics() {
+        // Rule 9.13.2-2 caps the Source List Size at 511.
+        ContextAssociationLists::default().set_source_list(&vec![0u32; 512]);
+    }
+
+    #[test]
+    fn async_list_over_511_round_trips() {
+        // Regression: the Asynchronous-Channel List Size is a 15-bit field (Rule 9.13.2-5),
+        // so a list longer than 511 must survive serialization. A 9-bit size mask would
+        // truncate the parsed count to len % 512 (600 -> 88) and corrupt the round trip.
+        let ids: Vec<u32> = (0..600).map(|i| 0xDD00_0000 | i).collect();
+        let mut c = ContextAssociationLists::default();
+        c.set_async_channel_list(&ids);
+        let parsed = from_be_bytes(&to_be_bytes(&c));
+        assert_eq!(parsed.async_channel_list().len(), 600);
+        assert_eq!(parsed.async_channel_list(), ids.as_slice());
+    }
+
+    #[test]
+    #[should_panic(expected = "async-channel list size must be 0..=32767")]
+    fn async_list_over_cap_panics() {
+        // Rule 9.13.2-5 caps the Asynchronous-Channel List Size at 32,767.
+        ContextAssociationLists::default().set_async_channel_list(&vec![0u32; 32_768]);
     }
 }

--- a/vita49/src/errors.rs
+++ b/vita49/src/errors.rs
@@ -64,4 +64,7 @@ pub enum VitaError {
     /// Error given when trying to set a reserved value.
     #[error("attempted to set reserved field")]
     ReservedField,
+    /// Error given when GPS ASCII payload bytes are not valid UTF-8.
+    #[error("GPS ASCII payload is not valid UTF-8")]
+    InvalidAscii(#[from] std::string::FromUtf8Error),
 }

--- a/vita49/src/gps_ascii.rs
+++ b/vita49/src/gps_ascii.rs
@@ -8,7 +8,37 @@ Data structures and methods related to the ASCII GPS format
 
 use deku::prelude::*;
 
+use crate::VitaError;
+
 /// Base ASCII GPS data structure.
+///
+/// Some GPS devices emit their fixes as formatted ASCII "sentences" (e.g. NMEA-0183); the
+/// GPS ASCII field (§9.4.7) carries those sentences verbatim. Word 1 holds the GPS/INS
+/// Manufacturer OUI, word 2 the number of 32-bit ASCII words (Rule 9.4.7-3), and the
+/// remaining words the packed sentence bytes.
+///
+/// The sentence bytes are packed big-endian to match the VITA-49 wire convention: per Figure
+/// 9.4.7-1 the first character (Byte 1) occupies bits 31:24 of word 3, so serializing the
+/// packet big-endian (as `Vrt` does) lays the bytes out in order Byte 1, Byte 2, …. The
+/// setters here pack with [`u32::from_be_bytes`] and the getters unpack with
+/// [`u32::to_be_bytes`] so this holds regardless of the host's native endianness.
+///
+/// # Example
+///
+/// ```
+/// use vita49::GpsAscii;
+///
+/// // A default value is empty; fill in the OUI and the ASCII sentence(s).
+/// let mut gps = GpsAscii::default();
+/// gps.set_manufacturer_oui(0x0A_1B2C);
+/// gps.set_sentences("$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47\r\n");
+///
+/// assert_eq!(gps.manufacturer_oui(), 0x0A_1B2C);
+/// assert_eq!(
+///     gps.sentences().unwrap(),
+///     "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47\r\n"
+/// );
+/// ```
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, DekuRead, DekuWrite)]
 #[deku(endian = "endian", ctx = "endian: deku::ctx::Endian")]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -25,5 +55,175 @@ impl GpsAscii {
         (((std::mem::size_of_val(&self.w1) + std::mem::size_of_val(&self.num_words))
             / std::mem::size_of::<u32>())
             + self.num_words as usize) as u16
+    }
+
+    /// The GPS/INS Manufacturer OUI (Rule 9.4.7-2); `FF-FF-FF` when unknown (Perm 9.4.5-2).
+    pub fn manufacturer_oui(&self) -> u32 {
+        self.w1 & 0x00FF_FFFF
+    }
+    /// Set the GPS/INS Manufacturer OUI (low 24 bits used).
+    pub fn set_manufacturer_oui(&mut self, oui: u32) {
+        self.w1 = (self.w1 & 0xFF00_0000) | (oui & 0x00FF_FFFF);
+    }
+
+    /// The raw ASCII sentence bytes (words 3…N+2), including any trailing NUL padding.
+    ///
+    /// Each 32-bit word is unpacked big-endian ([`u32::to_be_bytes`]) so the bytes come back
+    /// in wire order Byte 1, Byte 2, … (Figure 9.4.7-1). Internal: callers use
+    /// [`sentences`](Self::sentences), which validates UTF-8.
+    fn ascii_bytes(&self) -> Vec<u8> {
+        self.ascii.iter().flat_map(|w| w.to_be_bytes()).collect()
+    }
+
+    /// Set the raw ASCII sentence bytes, updating the Number of Words subfield.
+    ///
+    /// The bytes are NUL-padded (`0x00`) up to a multiple of four (Rule 9.4.7-5) and packed
+    /// four-per-word big-endian ([`u32::from_be_bytes`]) so that, once the packet is
+    /// serialized big-endian, Byte 1 lands in bits 31:24 of word 3 (Figure 9.4.7-1).
+    /// `num_words` is set to the resulting number of 32-bit words (Rule 9.4.7-3). Internal:
+    /// callers use [`set_sentences`](Self::set_sentences), which enforces ASCII.
+    fn set_ascii_bytes(&mut self, bytes: &[u8]) {
+        let words: Vec<u32> = bytes
+            .chunks(4)
+            .map(|chunk| {
+                // Short final chunk stays NUL-padded via the zero-initialized buffer.
+                let mut buf = [0u8; 4];
+                buf[..chunk.len()].copy_from_slice(chunk);
+                u32::from_be_bytes(buf)
+            })
+            .collect();
+        self.num_words = words.len() as u32;
+        self.ascii = words;
+    }
+
+    /// Set the ASCII GPS sentence(s), e.g. an NMEA-0183 string (Rule 9.4.7-4).
+    ///
+    /// Multiple sentences may be concatenated into a single field (Permission 9.4.7-1). The
+    /// bytes are NUL-padded to a 32-bit boundary and `num_words` is updated (Rule 9.4.7-3).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `s` is not ASCII. Rule 9.4.7-4 requires the field to carry complete ASCII
+    /// sentences, so non-ASCII input (e.g. UTF-8 multibyte) is rejected here rather than
+    /// written to the wire.
+    pub fn set_sentences(&mut self, s: &str) {
+        assert!(
+            s.is_ascii(),
+            "GPS ASCII sentences must be ASCII (Rule 9.4.7-4)"
+        );
+        self.set_ascii_bytes(s.as_bytes());
+    }
+
+    /// The ASCII GPS sentence(s) as a string, with trailing NUL padding stripped.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VitaError::InvalidAscii`] if the payload bytes are not valid UTF-8 — e.g. a
+    /// malformed or non-conforming received packet. Conforming ASCII sentences (Rule 9.4.7-4)
+    /// always decode.
+    pub fn sentences(&self) -> Result<String, VitaError> {
+        let bytes = self.ascii_bytes();
+        let end = bytes.iter().rposition(|&b| b != 0).map_or(0, |i| i + 1);
+        Ok(String::from_utf8(bytes[..end].to_vec())?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use deku::ctx::Endian;
+    use deku::reader::Reader;
+    use deku::writer::Writer;
+    use std::io::Cursor;
+
+    /// Serialize big-endian, matching the VITA-49 wire convention (`Vrt` is `endian = "big"`).
+    fn to_be_bytes(g: &GpsAscii) -> Vec<u8> {
+        let mut out = Vec::new();
+        {
+            let mut writer = Writer::new(Cursor::new(&mut out));
+            g.to_writer(&mut writer, Endian::Big).unwrap();
+            writer.finalize().unwrap();
+        }
+        out
+    }
+
+    /// Parse back the big-endian wire bytes.
+    fn from_be_bytes(bytes: &[u8]) -> GpsAscii {
+        let mut cursor = Cursor::new(bytes);
+        let mut reader = Reader::new(&mut cursor);
+        GpsAscii::from_reader_with_ctx(&mut reader, Endian::Big).unwrap()
+    }
+
+    #[test]
+    fn default_is_empty() {
+        let g = GpsAscii::default();
+        assert_eq!(g.manufacturer_oui(), 0);
+        assert_eq!(g.sentences().unwrap(), "");
+        assert!(g.ascii_bytes().is_empty());
+        // Just the two header words.
+        assert_eq!(g.size_words(), 2);
+    }
+
+    #[test]
+    fn nmea_sentence_round_trips_on_the_wire() {
+        let sentence = "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47\r\n";
+        let mut g = GpsAscii::default();
+        g.set_manufacturer_oui(0x0A_1B2C);
+        g.set_sentences(sentence);
+
+        // Rule 9.4.7-3: number of 32-bit words needed to convey the sentence.
+        let expected_words = ((sentence.len() + 3) / 4) as u32;
+        assert_eq!(g.sentences().unwrap(), sentence);
+        assert_eq!(g.size_words(), (2 + expected_words) as u16);
+
+        let bytes = to_be_bytes(&g);
+        // Word 1 = OUI, word 2 = num_words, big-endian.
+        assert_eq!(&bytes[0..4], &[0x00, 0x0A, 0x1B, 0x2C]);
+        assert_eq!(&bytes[4..8], &expected_words.to_be_bytes());
+        // Words 3.. carry the ASCII in wire order Byte 1..Byte 4 (Figure 9.4.7-1).
+        assert_eq!(&bytes[8..8 + sentence.len()], sentence.as_bytes());
+
+        let parsed = from_be_bytes(&bytes);
+        assert_eq!(parsed, g);
+        assert_eq!(parsed.manufacturer_oui(), 0x0A_1B2C);
+        assert_eq!(parsed.sentences().unwrap(), sentence);
+    }
+
+    #[test]
+    fn non_word_aligned_sentence_is_nul_padded() {
+        // Length 5 is not a multiple of 4, so it pads to 8 bytes / 2 words.
+        let sentence = "$GPGG";
+        assert_ne!(
+            sentence.len() % 4,
+            0,
+            "guard: sentence length must be non-aligned"
+        );
+        let mut g = GpsAscii::default();
+        g.set_sentences(sentence);
+
+        assert_eq!(g.ascii_bytes(), b"$GPGG\0\0\0");
+        assert_eq!(g.sentences().unwrap(), sentence);
+
+        let parsed = from_be_bytes(&to_be_bytes(&g));
+        assert_eq!(parsed, g);
+        assert_eq!(parsed.sentences().unwrap(), sentence);
+        // Padding word count = ceil(5 / 4) = 2.
+        assert_eq!(parsed.size_words(), 4);
+    }
+
+    #[test]
+    #[should_panic(expected = "GPS ASCII sentences must be ASCII")]
+    fn non_ascii_sentence_panics() {
+        // Rule 9.4.7-4: the field carries complete ASCII sentences only.
+        GpsAscii::default().set_sentences("café");
+    }
+
+    #[test]
+    fn non_utf8_payload_is_flagged() {
+        // A received packet carrying non-UTF-8 bytes surfaces an error rather than
+        // silently substituting the replacement character.
+        let mut g = GpsAscii::default();
+        g.set_ascii_bytes(&[0xFF, 0xFE, 0x00, 0x00]);
+        assert!(matches!(g.sentences(), Err(VitaError::InvalidAscii(_))));
     }
 }


### PR DESCRIPTION
Two independent construction APIs for fields that could be parsed but not built, in the same spirit as the `FormattedGps`/`EcefEphemeris` setters.

## `feat(gps_ascii)`: public construction API

`GpsAscii` (§9.4.7) exposed only `size_words()`. This adds:
- `manufacturer_oui`/`set_manufacturer_oui` (GPS/INS OUI; Rule 9.4.7-2 follows the Formatted GPS rules).
- `set_sentences(&str)`/`sentences() -> String` — carry NMEA-0183 (or other) sentences verbatim; the bytes are NUL-padded to a 32-bit boundary (Rule 9.4.7-5) and packed big-endian so that, serialized big-endian, Byte 1 lands in bits 31:24 of word 3 (Figure 9.4.7-1). `num_words` is kept in sync (Rule 9.4.7-3).
- `set_ascii_bytes(&[u8])`/`ascii_bytes() -> Vec<u8>` for the raw bytes.

## `feat(context_association_lists)`: public construction API

`ContextAssociationLists` (§9.13.2) exposed only `size_words()`. This adds getters and setters for the Source, System, Vector-Component, and Asynchronous-Channel lists, plus the Asynchronous-Channel Tag list and its "A" bit. Each setter keeps the corresponding size subfield in word 1/word 2 in sync while preserving the other lists, and enforces the spec size caps (Source/System ≤ 511 per Rules 9.13.2-2/-3). Stream IDs are passed as `&[u32]`.

Each change includes round-trip unit tests and a doc example.