### PR TITLE
fix: return parsing errors rather than panics

### DIFF
--- a/vita49/src/command.rs
+++ b/vita49/src/command.rs
@@ -22,6 +22,7 @@ use deku::prelude::*;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Command {
     /// Control acknowledgement mode.
+    #[deku(assert = "Command::validate_cam(cam, packet_header)")]
     cam: ControlAckMode,
     /// Message ID.
     message_id: u32,
@@ -60,6 +61,19 @@ impl Default for Command {
 }
 
 impl Command {
+    fn validate_cam(cam: &ControlAckMode, packet_header: &PacketHeader) -> bool {
+        if let Ok(true) = packet_header.is_ack_packet() {
+            let selected_count = [cam.validation(), cam.execution(), cam.state()]
+                .iter()
+                .filter(|&x| *x)
+                .count();
+            if selected_count != 1 {
+                return false;
+            }
+        }
+        true
+    }
+
     /// Create a new, empty control packet.
     pub fn new_control() -> Command {
         Command::default()
@@ -345,5 +359,38 @@ mod tests {
         command.set_cam(cam);
         command.controllee_id = Some(123);
         command.controller_uuid = Some(321);
+    }
+
+    #[test]
+    fn ack_packet_with_multiple_cam_ack_types_fails_deku_parsing() {
+        use deku::DekuContainerWrite;
+
+        let mut packet = Vrt::new_validation_ack_packet();
+        packet.update_packet_size();
+        let mut bytes = packet.to_bytes().unwrap();
+
+        // In Command, the CAM is the 32-bit word immediately following Stream ID (if stream ID included).
+        // For new_validation_ack_packet: header (4 bytes) + stream_id (4 bytes) = CAM at offset 8..12.
+        // Set both validation (bit 20) and execution (bit 19) in CAM.
+        // Bytes 8..12 in big endian: bit 20 is byte 9 bit 4, bit 19 is byte 9 bit 3.
+        bytes[9] |= (1 << 4) | (1 << 3);
+
+        let res = Vrt::try_from(&bytes[..]);
+        assert!(matches!(res, Err(deku::DekuError::Assertion(_))));
+    }
+
+    #[test]
+    fn ack_packet_with_no_cam_ack_types_fails_deku_parsing() {
+        use deku::DekuContainerWrite;
+
+        let mut packet = Vrt::new_validation_ack_packet();
+        packet.update_packet_size();
+        let mut bytes = packet.to_bytes().unwrap();
+
+        // Clear validation bit (bit 20), execution bit (bit 19), state bit (bit 18)
+        bytes[9] &= !((1 << 4) | (1 << 3) | (1 << 2));
+
+        let res = Vrt::try_from(&bytes[..]);
+        assert!(matches!(res, Err(deku::DekuError::Assertion(_))));
     }
 }

--- a/vita49/src/control_ack_mode.rs
+++ b/vita49/src/control_ack_mode.rs
@@ -16,7 +16,7 @@ use deku::prelude::*;
 )]
 #[deku(endian = "endian", ctx = "endian: deku::ctx::Endian")]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ControlAckMode(u32);
+pub struct ControlAckMode(#[deku(assert = "ControlAckMode::validate_cam_raw(*field_0)")] u32);
 
 /// Identification format (128-bit UUID or 32-bit ID).
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
@@ -59,6 +59,12 @@ pub enum TimingControlMode {
 }
 
 impl ControlAckMode {
+    pub(crate) fn validate_cam_raw(val: u32) -> bool {
+        let action_mode_bits = (val >> 23) & 0b11;
+        let timing_control_bits = (val >> 12) & 0b111;
+        action_mode_bits != 0b11 && timing_control_bits <= 0b100
+    }
+
     /// Generate a new Control Ack Mode field that's zeroed out.
     pub fn new(&self) -> ControlAckMode {
         ControlAckMode::default()
@@ -367,5 +373,30 @@ impl fmt::Display for ControlAckMode {
         writeln!(f, "  Error: {}", self.error())?;
         writeln!(f, "  Timing control: {:?}", self.timing_control())?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_action_mode_fails_deku_parsing() {
+        // Bit 24:23 = 0b11 is invalid action mode
+        let invalid_cam_bytes: [u8; 4] = [0b0000_0001, 0b1000_0000, 0, 0];
+        let mut cursor = deku::no_std_io::Cursor::new(&invalid_cam_bytes[..]);
+        let mut reader = deku::reader::Reader::new(&mut cursor);
+        let res = ControlAckMode::from_reader_with_ctx(&mut reader, deku::ctx::Endian::Big);
+        assert!(matches!(res, Err(deku::DekuError::Assertion(_))));
+    }
+
+    #[test]
+    fn invalid_timing_control_fails_deku_parsing() {
+        // Bits 14:12 > 0b100 (e.g. 0b101 = 5) is invalid timing control
+        let invalid_cam_bytes: [u8; 4] = [0, 0, 0b0101_0000, 0];
+        let mut cursor = deku::no_std_io::Cursor::new(&invalid_cam_bytes[..]);
+        let mut reader = deku::reader::Reader::new(&mut cursor);
+        let res = ControlAckMode::from_reader_with_ctx(&mut reader, deku::ctx::Endian::Big);
+        assert!(matches!(res, Err(deku::DekuError::Assertion(_))));
     }
 }

--- a/vita49/src/packet_header.rs
+++ b/vita49/src/packet_header.rs
@@ -17,7 +17,9 @@ use crate::VitaError;
 #[deku(endian = "endian", ctx = "endian: deku::ctx::Endian")]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PacketHeader {
+    #[deku(assert = "PacketHeader::validate_hword_1(*hword_1)")]
     hword_1: u16,
+    #[deku(assert = "PacketHeader::validate_packet_size(*hword_1, *packet_size)")]
     packet_size: u16,
 }
 
@@ -332,6 +334,41 @@ impl TryFrom<u8> for Tsf {
 }
 
 impl PacketHeader {
+    fn validate_hword_1(hword_1: u16) -> bool {
+        let packet_type_bits = ((hword_1 >> 12) & 0b1111) as u8;
+        PacketType::try_from(packet_type_bits).is_ok()
+    }
+
+    fn validate_packet_size(hword_1: u16, packet_size: u16) -> bool {
+        let dummy_header = PacketHeader {
+            hword_1,
+            packet_size,
+        };
+        packet_size >= dummy_header.min_packet_size_words()
+    }
+
+    /// Returns the minimum packet size in 32-bit words required to contain
+    /// the packet header and its enabled optional header/trailer fields.
+    pub fn min_packet_size_words(&self) -> u16 {
+        let mut min = 1; // 32-bit header itself
+        if self.stream_id_included() {
+            min += 1;
+        }
+        if self.class_id_included() {
+            min += 2;
+        }
+        if self.integer_timestamp_included() {
+            min += 1;
+        }
+        if self.fractional_timestamp_included() {
+            min += 2;
+        }
+        if self.trailer_included() {
+            min += 1;
+        }
+        min
+    }
+
     /// Gets the raw 32-bit value of the packet header.
     pub fn as_u32(&self) -> u32 {
         ((self.hword_1 as u32) << 16) | ((self.packet_size as u32) & 0xFFFF)
@@ -572,6 +609,27 @@ mod tests {
         let packet = Vrt::new_control_packet();
         assert_eq!(packet.header().packet_type(), PacketType::Command);
         assert_eq!(packet.header().as_u32() >> 28, 0b0110);
+    }
+
+    #[test]
+    fn invalid_packet_type_fails_deku_parsing() {
+        use crate::prelude::*;
+        // Packet type is upper 4 bits of hword_1 (bits 12..=15).
+        // 0x8000 sets packet type to 0x8, which is invalid (reserved values are 0x8..=0xF).
+        let invalid_header_bytes: [u8; 4] = [0x80, 0x00, 0x00, 0x01];
+        let res = Vrt::try_from(&invalid_header_bytes[..]);
+        assert!(matches!(res, Err(deku::DekuError::Assertion(_))));
+    }
+
+    #[test]
+    fn invalid_packet_size_fails_deku_parsing() {
+        use crate::prelude::*;
+        // Signal data packet with stream ID (packet type 0x1) requires at least:
+        // 1 (header) + 1 (stream_id) = 2 words.
+        // Giving packet_size = 0 or 1 should fail assertion.
+        let invalid_header_bytes: [u8; 4] = [0x10, 0x00, 0x00, 0x01];
+        let res = Vrt::try_from(&invalid_header_bytes[..]);
+        assert!(matches!(res, Err(deku::DekuError::Assertion(_))));
     }
 
     #[test]


### PR DESCRIPTION
Currently, there are a few cases where this crate uses opaque packed fields to speed up parsing, but can then read in invalid data which fails to meet assumptions later. This can cause a panic at the binary level which is frustrating for users.

Instead, let's make use of the deku `assert` directive which allows us to perform some validation and flag errors at parse time. This should help us guarantee that once you've parsed a packet into the struct, it's valid and won't cause your app to panic.